### PR TITLE
add dependency downgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,46 +1,50 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup Label=".NET">
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-    <PackageVersion Include="FluentValidation" Version="11.10.0" />
-  </ItemGroup>
-  <ItemGroup Label="Analyzers">
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.179">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageVersion>
-  </ItemGroup>
-  <ItemGroup Label="DevOps">
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageVersion>
-  </ItemGroup>
-  <ItemGroup Label="Tests">
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="NSubstitute" Version="5.0.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <ItemGroup Label=".NET Dependencies">
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Label="DevOps">
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageVersion>
+    </ItemGroup>
+
+    <ItemGroup Label="Tests">
+        <PackageVersion Include="FluentValidation" Version="11.10.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageVersion Include="xunit" Version="2.9.2" />
+        <PackageVersion Include="xunit.runner.console" Version="2.9.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Label="Analyzers">
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.3.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+        <PackageVersion Include="Meziantou.Analyzer" Version="2.0.179">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageVersion>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes changes to the `Directory.Packages.props` file to reorganize and update package dependencies. The most important changes include updating the versions of several packages and restructuring the `ItemGroup` labels for better clarity.

Updates and restructuring of package dependencies:

* Updated the version of `System.Text.Json` to `8.0.5` and `Microsoft.EntityFrameworkCore` to `8.0.11` under a new `ItemGroup` label `.NET Dependencies`. We dont need `9.0.0` today.
* Moved the `FluentValidation` package version to the `Tests` `ItemGroup` and ensured it remains at version `11.10.0`.
* Reintroduced the `Analyzers` `ItemGroup` with the same package versions as before, including `Roslynator.Analyzers`, `Microsoft.CodeAnalysis.Common`, `Microsoft.CodeAnalysis.CSharp`, and `Meziantou.Analyzer`.