### PR TITLE
Fixes Analyzer warning because of missing PrivateAssets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,11 +28,11 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)BenjaminAbt.StrongOf.snk</AssemblyOriginatorKeyFile>
 
     <PublicKey>
-        0024000004800000940000000602000000240000525341310004000001000100a19f5c9b522bba
-        2b14442a92edac88ebfad09ade036005cdbcfdb574e78f5b60612a92b18b73acb1a3ecc933fb2d
-        5836f648ef15819a49eea44b6de6d9966375cc4fa08f523c18463f4ee57ef3ed63500a993e125f
-        44a374ea17b450962a1b14a13d8ccb0c36d7d3886e54a739103aa32d8c66b92aa25880e80ec088
-        1e91649c
+      0024000004800000940000000602000000240000525341310004000001000100a19f5c9b522bba
+      2b14442a92edac88ebfad09ade036005cdbcfdb574e78f5b60612a92b18b73acb1a3ecc933fb2d
+      5836f648ef15819a49eea44b6de6d9966375cc4fa08f523c18463f4ee57ef3ed63500a993e125f
+      44a374ea17b450962a1b14a13d8ccb0c36d7d3886e54a739103aa32d8c66b92aa25880e80ec088
+      1e91649c
     </PublicKey>
   </PropertyGroup>
 
@@ -53,8 +53,8 @@
 
     <Title>StrongOf - Strong Type your stuff!</Title>
     <Description>
-            StrongOf helps to implement primitives as a strong type that represents a domain object (e.g. UserId, EmailAddress, etc.). It is a simple class that wraps a value and provides a few helper methods to make it easier to work with.
-            In contrast to other approaches, StrongOf is above all simple and performant - and not over-engineered.
+      StrongOf helps to implement primitives as a strong type that represents a domain object (e.g. UserId, EmailAddress, etc.). It is a simple class that wraps a value and provides a few helper methods to make it easier to work with.
+      In contrast to other approaches, StrongOf is above all simple and performant - and not over-engineered.
     </Description>
     <PackageProjectUrl>https://github.com/BenjaminAbt/StrongOf</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BenjaminAbt/StrongOf</RepositoryUrl>
@@ -110,9 +110,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Meziantou.Analyzer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,9 +55,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.195">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This pull request refines the package configuration for `Microsoft.CodeAnalysis` dependencies by explicitly adding `PrivateAssets` and `IncludeAssets` metadata to ensure consistent behavior across builds. These changes affect both `Directory.Build.props` and `Directory.Packages.props`.

### Package Configuration Updates:

* In `Directory.Build.props`, the `Microsoft.CodeAnalysis.CSharp.Workspaces`, `Microsoft.CodeAnalysis.Common`, and `Microsoft.CodeAnalysis.CSharp` package references were updated to include explicit `<PrivateAssets>` and `<IncludeAssets>` metadata for better dependency management.
* In `Directory.Packages.props`, the `Microsoft.CodeAnalysis.CSharp.Workspaces`, `Microsoft.CodeAnalysis.Common`, and `Microsoft.CodeAnalysis.CSharp` package versions were updated similarly to include explicit `<PrivateAssets>` and `<IncludeAssets>` metadata.